### PR TITLE
Fix allow query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ what forms the strings can take (this should be familiar to express users).
 ```javascript
 const Toisu = require('toisu');
 const Router = require('toisu-router');
-const http;
+const http = require('http');
 
 const app = new Toisu();
 const router = new Router();

--- a/lib/Route.js
+++ b/lib/Route.js
@@ -3,6 +3,7 @@
 const pathToRegexp = require('path-to-regexp');
 const normalizeHandlers = require('./normalizeHandlers');
 const makeParams = require('./makeParams');
+const url = require('url');
 
 function makeNotAllowed(allowedMethods) {
   return function notAllowed(req, res) {
@@ -23,7 +24,8 @@ class Route {
   }
 
   match(req) {
-    const paramList = this.regex.exec(req.url);
+    const pathname = url.parse(req.url).pathname;
+    const paramList = this.regex.exec(pathname);
 
     if (paramList) {
       return {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "toisu": "3.0.2"
   },
   "dependencies": {
-    "path-to-regexp": "1.5.3",
-    "toisu-middleware-runner": "1.0.3"
+    "path-to-regexp": "1.6.0",
+    "toisu-middleware-runner": "1.0.4"
   },
   "engines": {
     "node": ">=4.2"

--- a/test/Route.js
+++ b/test/Route.js
@@ -106,5 +106,23 @@ describe('Route', () => {
         assert.equal(result.middlewares, getMiddlewares);
       });
     });
+
+    describe('requests with the same path, a matchin HTTP method, and a search string', () => {
+      let result;
+
+      beforeEach(() => {
+        result = route.match({ url: '/some/path/123?blah=bleh', method: 'GET' });
+      });
+
+      it('returns an object with a params object and a middlewares array', () => {
+        assert.deepEqual(Object.keys(result).sort(), ['middlewares', 'params']);
+        assert.deepEqual(result.params, { someParam: '123' });
+        assert.ok(Array.isArray(result.middlewares));
+      });
+
+      it('uses the handler middlwares in the returned object', () => {
+        assert.equal(result.middlewares, getMiddlewares);
+      });
+    });
   });
 });


### PR DESCRIPTION
Search strings were messing with path matching. This PR alters path matching to operate on URL path names to fix this.
